### PR TITLE
Conversion between GTIN formats

### DIFF
--- a/lib/barcodevalidation/digit.rb
+++ b/lib/barcodevalidation/digit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "delegate"
+require_relative "error/argument_error_class"
 
 module BarcodeValidation
   class Digit < DelegateClass(Integer)

--- a/lib/barcodevalidation/digit_sequence.rb
+++ b/lib/barcodevalidation/digit_sequence.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "forwardable"
+require_relative "error/argument_error_class"
 
 module BarcodeValidation
   class DigitSequence < Array

--- a/lib/barcodevalidation/gtin.rb
+++ b/lib/barcodevalidation/gtin.rb
@@ -12,7 +12,7 @@ require_relative "gtin/gtin14"
 module BarcodeValidation
   module GTIN
     def self.new(input)
-      module_eval("GTIN#{input.to_s.size}").new(input)
+      module_eval("GTIN#{input.to_s.size}", __FILE__, __LINE__).new(input)
     rescue NameError => e
       BarcodeValidation::InvalidGTIN.new(input, error: e)
     end

--- a/lib/barcodevalidation/gtin.rb
+++ b/lib/barcodevalidation/gtin.rb
@@ -11,10 +11,18 @@ require_relative "gtin/gtin14"
 
 module BarcodeValidation
   module GTIN
-    def self.new(input)
-      module_eval("GTIN#{input.to_s.size}", __FILE__, __LINE__).new(input)
-    rescue NameError => e
-      BarcodeValidation::InvalidGTIN.new(input, error: e)
+    class << self
+      def new(input)
+        (class_for_input(input) || BarcodeValidation::InvalidGTIN).new(input)
+      end
+
+      private
+
+      def class_for_input(input)
+        [GTIN8, GTIN12, GTIN13, GTIN14].find do |klass|
+          input.to_s.size == klass::VALID_LENGTH
+        end
+      end
     end
   end
 end

--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -82,7 +82,7 @@ module BarcodeValidation
       # BarcodeValidation::InvalidGTIN with valid? = false and a meaningful
       # error message.
       def transcode_to(klass)
-        gtin = klass.new("%0#{klass.new(nil).valid_length}d" % to_s.gsub(/^0+/, ""))
+        gtin = klass.new(format("%0#{klass.new(nil).valid_length}d", to_s.gsub(/^0+/, "")))
 
         if gtin.valid?
           gtin

--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -1,0 +1,52 @@
+require "forwardable"
+
+module BarcodeValidation
+  module GTIN
+    class Base < BarcodeValidation::DigitSequence
+      MODULUS = 10
+
+      extend Forwardable
+
+      attr_reader :input
+
+      def initialize(input)
+        @input = input
+
+        super
+      rescue BarcodeValidation::Error => e
+        BarcodeValidation::InvalidGTIN.new(input, error: e)
+      end
+
+      def valid?
+        valid_length == length && check_digit.valid?
+      end
+
+      def valid_length
+        raise AbstractMethodError.new("Concrete classes must define #valid_length")
+      end
+
+      class AbstractMethodError < StandardError; end
+
+      private
+
+      def check_digit
+        CheckDigit.new(last, expected: expected_check_digit)
+      end
+
+      def expected_check_digit
+        (MODULUS - weighted_checkable_digit_sum) % MODULUS
+      end
+
+      def weighted_checkable_digit_sum
+        checkable_digits
+          .zip([3, 1].cycle)
+          .map { |digit, factor| digit * factor }
+          .reduce(&:+)
+      end
+
+      def checkable_digits
+        take(length - 1).reverse.map(&:to_i)
+      end
+    end
+  end
+end

--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -24,7 +24,9 @@ module BarcodeValidation
       end
 
       def valid_length
-        raise AbstractMethodError, "Concrete classes must define #valid_length"
+        raise(AbstractMethodError, "Concrete classes must define the VALID_LENGTH constant") unless self.class.const_defined?(:VALID_LENGTH)
+
+        self.class::VALID_LENGTH
       end
 
       class AbstractMethodError < StandardError; end
@@ -82,7 +84,7 @@ module BarcodeValidation
       # BarcodeValidation::InvalidGTIN with valid? = false and a meaningful
       # error message.
       def transcode_to(klass)
-        gtin = klass.new(format("%0#{klass.new(nil).valid_length}d", to_s.gsub(/^0+/, "")))
+        gtin = klass.new(format("%0#{klass::VALID_LENGTH}d", to_s.gsub(/^0+/, "")))
 
         if gtin.valid?
           gtin

--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 
 module BarcodeValidation

--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -27,6 +27,15 @@ module BarcodeValidation
 
       class AbstractMethodError < StandardError; end
 
+      def to_all_valid
+        [
+          to_gtin_8,
+          to_gtin_12,
+          to_gtin_13,
+          to_gtin_14
+        ].select(&:valid?)
+      end
+
       def to_gtin_8
         is_a?(GTIN8) ? self : transcode_to(GTIN8)
       end

--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -24,7 +24,7 @@ module BarcodeValidation
       end
 
       def valid_length
-        raise AbstractMethodError.new("Concrete classes must define #valid_length")
+        raise AbstractMethodError, "Concrete classes must define #valid_length"
       end
 
       class AbstractMethodError < StandardError; end
@@ -34,7 +34,7 @@ module BarcodeValidation
           to_gtin_8,
           to_gtin_12,
           to_gtin_13,
-          to_gtin_14
+          to_gtin_14,
         ].select(&:valid?)
       end
 
@@ -82,12 +82,16 @@ module BarcodeValidation
       # BarcodeValidation::InvalidGTIN with valid? = false and a meaningful
       # error message.
       def transcode_to(klass)
-        gtin = klass.new("%0#{klass.new(nil).valid_length}d" % self.to_s.gsub(/^0+/, ""))
+        gtin = klass.new("%0#{klass.new(nil).valid_length}d" % to_s.gsub(/^0+/, ""))
 
-        gtin.valid? ? gtin : BarcodeValidation::InvalidGTIN.new(
-          input,
-          error: klass::ConversionError.new(klass).exception(input)
-        )
+        if gtin.valid?
+          gtin
+        else
+          BarcodeValidation::InvalidGTIN.new(
+            input,
+            error: klass::ConversionError.new(klass).exception(input),
+          )
+        end
       end
 
       ConversionError = Error::ArgumentErrorClass.new(self)

--- a/lib/barcodevalidation/gtin/check_digit.rb
+++ b/lib/barcodevalidation/gtin/check_digit.rb
@@ -1,0 +1,26 @@
+module BarcodeValidation
+  module GTIN
+    class CheckDigit < DelegateClass(Digit)
+      include Adamantium::Flat
+      include Mixin::ValueObject
+
+      attr_reader :actual, :expected
+
+      def initialize(actual, expected: nil)
+        expected = actual if expected.nil?
+        @expected = Digit.new(expected)
+        @actual = Digit.new(actual)
+        super(@actual)
+      end
+
+      def valid?
+        actual == expected
+      end
+
+      def inspect
+        return super if valid?
+        "#<#{self.class}(#{actual}) invalid: expected #{expected}>"
+      end
+    end
+  end
+end

--- a/lib/barcodevalidation/gtin/check_digit.rb
+++ b/lib/barcodevalidation/gtin/check_digit.rb
@@ -21,6 +21,7 @@ module BarcodeValidation
 
       def inspect
         return super if valid?
+
         "#<#{self.class}(#{actual}) invalid: expected #{expected}>"
       end
     end

--- a/lib/barcodevalidation/gtin/check_digit.rb
+++ b/lib/barcodevalidation/gtin/check_digit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BarcodeValidation
   module GTIN
     class CheckDigit < DelegateClass(Digit)

--- a/lib/barcodevalidation/gtin/gtin12.rb
+++ b/lib/barcodevalidation/gtin/gtin12.rb
@@ -1,0 +1,9 @@
+module BarcodeValidation
+  module GTIN
+    class GTIN12 < BarcodeValidation::GTIN::Base
+      def valid_length
+        12
+      end
+    end
+  end
+end

--- a/lib/barcodevalidation/gtin/gtin12.rb
+++ b/lib/barcodevalidation/gtin/gtin12.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BarcodeValidation
   module GTIN
     class GTIN12 < BarcodeValidation::GTIN::Base

--- a/lib/barcodevalidation/gtin/gtin12.rb
+++ b/lib/barcodevalidation/gtin/gtin12.rb
@@ -3,9 +3,7 @@
 module BarcodeValidation
   module GTIN
     class GTIN12 < BarcodeValidation::GTIN::Base
-      def valid_length
-        12
-      end
+      VALID_LENGTH = 12
     end
   end
 end

--- a/lib/barcodevalidation/gtin/gtin13.rb
+++ b/lib/barcodevalidation/gtin/gtin13.rb
@@ -3,9 +3,7 @@
 module BarcodeValidation
   module GTIN
     class GTIN13 < BarcodeValidation::GTIN::Base
-      def valid_length
-        13
-      end
+      VALID_LENGTH = 13
     end
   end
 end

--- a/lib/barcodevalidation/gtin/gtin13.rb
+++ b/lib/barcodevalidation/gtin/gtin13.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BarcodeValidation
   module GTIN
     class GTIN13 < BarcodeValidation::GTIN::Base

--- a/lib/barcodevalidation/gtin/gtin13.rb
+++ b/lib/barcodevalidation/gtin/gtin13.rb
@@ -1,0 +1,9 @@
+module BarcodeValidation
+  module GTIN
+    class GTIN13 < BarcodeValidation::GTIN::Base
+      def valid_length
+        13
+      end
+    end
+  end
+end

--- a/lib/barcodevalidation/gtin/gtin14.rb
+++ b/lib/barcodevalidation/gtin/gtin14.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BarcodeValidation
   module GTIN
     class GTIN14 < BarcodeValidation::GTIN::Base

--- a/lib/barcodevalidation/gtin/gtin14.rb
+++ b/lib/barcodevalidation/gtin/gtin14.rb
@@ -1,0 +1,9 @@
+module BarcodeValidation
+  module GTIN
+    class GTIN14 < BarcodeValidation::GTIN::Base
+      def valid_length
+        14
+      end
+    end
+  end
+end

--- a/lib/barcodevalidation/gtin/gtin14.rb
+++ b/lib/barcodevalidation/gtin/gtin14.rb
@@ -3,9 +3,7 @@
 module BarcodeValidation
   module GTIN
     class GTIN14 < BarcodeValidation::GTIN::Base
-      def valid_length
-        14
-      end
+      VALID_LENGTH = 14
     end
   end
 end

--- a/lib/barcodevalidation/gtin/gtin8.rb
+++ b/lib/barcodevalidation/gtin/gtin8.rb
@@ -1,0 +1,9 @@
+module BarcodeValidation
+  module GTIN
+    class GTIN8 < BarcodeValidation::GTIN::Base
+      def valid_length
+        8
+      end
+    end
+  end
+end

--- a/lib/barcodevalidation/gtin/gtin8.rb
+++ b/lib/barcodevalidation/gtin/gtin8.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BarcodeValidation
   module GTIN
     class GTIN8 < BarcodeValidation::GTIN::Base

--- a/lib/barcodevalidation/gtin/gtin8.rb
+++ b/lib/barcodevalidation/gtin/gtin8.rb
@@ -3,9 +3,7 @@
 module BarcodeValidation
   module GTIN
     class GTIN8 < BarcodeValidation::GTIN::Base
-      def valid_length
-        8
-      end
+      VALID_LENGTH = 8
     end
   end
 end

--- a/spec/lib/barcodevalidation/gtin/gtin12_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin12_spec.rb
@@ -40,4 +40,95 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
       end
     end
   end
+
+  context "converstion" do
+    before do
+      expect(gtin.is_a?(described_class)).to be_truthy
+      expect(gtin).to be_valid
+    end
+
+    context "to GTIN-8" do
+      let(:gtin8) { gtin.to_gtin_8 }
+
+      context "when prefixed with zeros" do
+        let(:input) { "000012345670" }
+
+        it 'is valid' do
+          expect(gtin8).to be_valid
+        end
+
+        it 'is a BarcodeValidation::GTIN::GTIN8 instance' do
+          expect(gtin8.is_a?(BarcodeValidation::GTIN::GTIN8)).to be_truthy
+        end
+      end
+
+      context "when not prefixed with zeros" do
+        let(:input) { "123456789012" }
+
+        it 'is not valid' do
+          expect(gtin8).to_not be_valid
+        end
+
+        it 'is a BarcodeValidation::InvalidGTIN instance' do
+          expect(gtin8.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+        end
+      end
+    end
+
+    context "to GTIN-12" do
+      let(:input) { "123456789012" }
+
+      it 'returns itself' do
+        expect(gtin.to_gtin_12).to eq(gtin)
+      end
+    end
+
+    context "to GTIN-13" do
+      let(:gtin13) { gtin.to_gtin_13 }
+
+      before do
+        expect(gtin13.is_a?(BarcodeValidation::GTIN::GTIN13)).to be_truthy
+      end
+
+      context "when prefixed with zeros" do
+        let(:input) { "000012345670" }
+
+        it 'returns a valid GTIN-13' do
+          expect(gtin13).to be_valid
+        end
+      end
+
+      context "when not prefixed with zeros" do
+        let(:input) { "123456789012" }
+
+        it 'returns a valid GTIN-13' do
+          expect(gtin13).to be_valid
+        end
+      end
+    end
+
+    context "to GTIN-14" do
+      let(:gtin14) { gtin.to_gtin_14 }
+
+      before do
+        expect(gtin14.is_a?(BarcodeValidation::GTIN::GTIN14)).to be_truthy
+      end
+
+      context "when prefixed with zeros" do
+        let(:input) { "000012345670" }
+
+        it 'is valid' do
+          expect(gtin14).to be_valid
+        end
+      end
+
+      context "when not prefixed with zeros" do
+        let(:input) { "123456789012" }
+
+        it 'returns a valid GTIN-14' do
+          expect(gtin14).to be_valid
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/barcodevalidation/gtin/gtin12_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin12_spec.rb
@@ -130,5 +130,35 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
         end
       end
     end
+
+    context "to_all_valid" do
+      context "with a zero-padded GTIN-8 code" do
+        let(:input) { "000012345670" }
+
+        it 'includes a GTIN-8 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        end
+      end
+
+      context "when a GTIN-12 code without zero padding" do
+        let(:input) { "123456789012" }
+
+        it 'does not includes a GTIN-8 instance' do
+          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        end
+
+        it 'includes a GTIN-12 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+        end
+
+        it 'includes a zero-padded GTIN-13 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN13)}).to be_truthy
+        end
+
+        it 'includes a zero-padded GTIN-14 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN14)}).to be_truthy
+        end
+      end
+    end
   end
 end

--- a/spec/lib/barcodevalidation/gtin/gtin12_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin12_spec.rb
@@ -1,0 +1,43 @@
+require "barcodevalidation/mixin/has_check_digit"
+require "barcodevalidation/mixin/value_object"
+require "barcodevalidation/digit"
+require "barcodevalidation/digit_sequence"
+require "barcodevalidation/gtin"
+
+RSpec.describe BarcodeValidation::GTIN::GTIN12 do
+  subject(:gtin) { described_class.new(input) }
+
+  context "#valid?" do
+    context "whith a valid 8-digit code" do
+      let(:input) { "12345670" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+
+    context "with a valid 12-digit code" do
+      let(:input) { "123456789012" }
+
+      it 'is true' do
+        expect(gtin).to be_valid
+      end
+    end
+
+    context "with a valid 13-digit code" do
+      let(:input) { "1234567890128" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+
+    context "with a valid 14-digit code" do
+      let(:input) { "12345678901231" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/lib/barcodevalidation/gtin/gtin12_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin12_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "barcodevalidation/mixin/has_check_digit"
 require "barcodevalidation/mixin/value_object"
 require "barcodevalidation/digit"

--- a/spec/lib/barcodevalidation/gtin/gtin12_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin12_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
     context "whith a valid 8-digit code" do
       let(:input) { "12345670" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -21,7 +21,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
     context "with a valid 12-digit code" do
       let(:input) { "123456789012" }
 
-      it 'is true' do
+      it "is true" do
         expect(gtin).to be_valid
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
     context "with a valid 13-digit code" do
       let(:input) { "1234567890128" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
     context "with a valid 14-digit code" do
       let(:input) { "12345678901231" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -55,11 +55,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
       context "when prefixed with zeros" do
         let(:input) { "000012345670" }
 
-        it 'is valid' do
+        it "is valid" do
           expect(gtin8).to be_valid
         end
 
-        it 'is a BarcodeValidation::GTIN::GTIN8 instance' do
+        it "is a BarcodeValidation::GTIN::GTIN8 instance" do
           expect(gtin8.is_a?(BarcodeValidation::GTIN::GTIN8)).to be_truthy
         end
       end
@@ -67,11 +67,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
       context "when not prefixed with zeros" do
         let(:input) { "123456789012" }
 
-        it 'is not valid' do
+        it "is not valid" do
           expect(gtin8).to_not be_valid
         end
 
-        it 'is a BarcodeValidation::InvalidGTIN instance' do
+        it "is a BarcodeValidation::InvalidGTIN instance" do
           expect(gtin8.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
         end
       end
@@ -80,7 +80,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
     context "to GTIN-12" do
       let(:input) { "123456789012" }
 
-      it 'returns itself' do
+      it "returns itself" do
         expect(gtin.to_gtin_12).to eq(gtin)
       end
     end
@@ -95,7 +95,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
       context "when prefixed with zeros" do
         let(:input) { "000012345670" }
 
-        it 'returns a valid GTIN-13' do
+        it "returns a valid GTIN-13" do
           expect(gtin13).to be_valid
         end
       end
@@ -103,7 +103,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
       context "when not prefixed with zeros" do
         let(:input) { "123456789012" }
 
-        it 'returns a valid GTIN-13' do
+        it "returns a valid GTIN-13" do
           expect(gtin13).to be_valid
         end
       end
@@ -119,7 +119,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
       context "when prefixed with zeros" do
         let(:input) { "000012345670" }
 
-        it 'is valid' do
+        it "is valid" do
           expect(gtin14).to be_valid
         end
       end
@@ -127,7 +127,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
       context "when not prefixed with zeros" do
         let(:input) { "123456789012" }
 
-        it 'returns a valid GTIN-14' do
+        it "returns a valid GTIN-14" do
           expect(gtin14).to be_valid
         end
       end
@@ -137,28 +137,28 @@ RSpec.describe BarcodeValidation::GTIN::GTIN12 do
       context "with a zero-padded GTIN-8 code" do
         let(:input) { "000012345670" }
 
-        it 'includes a GTIN-8 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        it "includes a GTIN-8 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN8) }).to be_truthy
         end
       end
 
       context "when a GTIN-12 code without zero padding" do
         let(:input) { "123456789012" }
 
-        it 'does not includes a GTIN-8 instance' do
-          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        it "does not includes a GTIN-8 instance" do
+          expect(gtin.to_all_valid.none? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN8) }).to be_truthy
         end
 
-        it 'includes a GTIN-12 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+        it "includes a GTIN-12 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN12) }).to be_truthy
         end
 
-        it 'includes a zero-padded GTIN-13 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN13)}).to be_truthy
+        it "includes a zero-padded GTIN-13 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN13) }).to be_truthy
         end
 
-        it 'includes a zero-padded GTIN-14 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN14)}).to be_truthy
+        it "includes a zero-padded GTIN-14 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN14) }).to be_truthy
         end
       end
     end

--- a/spec/lib/barcodevalidation/gtin/gtin13_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin13_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
     context "whith a valid 8-digit code" do
       let(:input) { "12345670" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -21,7 +21,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
     context "with a valid 12-digit code" do
       let(:input) { "123456789012" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
     context "with a valid 13-digit code" do
       let(:input) { "1234567890128" }
 
-      it 'is true' do
+      it "is true" do
         expect(gtin).to be_valid
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
     context "with a valid 14-digit code" do
       let(:input) { "12345678901231" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -58,11 +58,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
       context "when prefixed with zeros" do
         let(:input) { "0000012345670" }
 
-        it 'is valid' do
+        it "is valid" do
           expect(gtin8).to be_valid
         end
 
-        it 'is a BarcodeValidation::GTIN::GTIN8' do
+        it "is a BarcodeValidation::GTIN::GTIN8" do
           expect(gtin8.is_a?(BarcodeValidation::GTIN::GTIN8)).to be_truthy
         end
       end
@@ -70,11 +70,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
       context "when not prefixed with zeros" do
         let(:input) { "1234567890128" }
 
-        it 'is not valid' do
+        it "is not valid" do
           expect(gtin8).to_not be_valid
         end
 
-        it 'is a BarcodeValidation::InvalidGTIN' do
+        it "is a BarcodeValidation::InvalidGTIN" do
           expect(gtin8.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
         end
       end
@@ -86,11 +86,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
       context "when prefixed with zeros" do
         let(:input) { "0123456789012" }
 
-        it 'is valid' do
+        it "is valid" do
           expect(gtin12).to be_valid
         end
 
-        it 'is a BarcodeValidation::GTIN::GTIN12' do
+        it "is a BarcodeValidation::GTIN::GTIN12" do
           expect(gtin12.is_a?(BarcodeValidation::GTIN::GTIN12)).to be_truthy
         end
       end
@@ -98,11 +98,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
       context "when not prefixed with zeros" do
         let(:input) { "1234567890128" }
 
-        it 'is not valid' do
+        it "is not valid" do
           expect(gtin12).to_not be_valid
         end
 
-        it 'is a BarcodeValidation::InvalidGTIN' do
+        it "is a BarcodeValidation::InvalidGTIN" do
           expect(gtin12.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
         end
       end
@@ -111,7 +111,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
     context "to GTIN-13" do
       let(:input) { "1234567890128" }
 
-      it 'returns itself' do
+      it "returns itself" do
         expect(gtin.to_gtin_13).to eq(gtin)
       end
     end
@@ -126,7 +126,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
       context "when prefixed with zeros" do
         let(:input) { "0123456789012" }
 
-        it 'returns a valid GTIN-14' do
+        it "returns a valid GTIN-14" do
           expect(gtin14).to be_valid
         end
       end
@@ -134,7 +134,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
       context "when not prefixed with zeros" do
         let(:input) { "1234567890128" }
 
-        it 'returns a valid GTIN-14' do
+        it "returns a valid GTIN-14" do
           expect(gtin14).to be_valid
         end
       end
@@ -144,36 +144,36 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
       context "with a zero-padded GTIN-8 code" do
         let(:input) { "0000012345670" }
 
-        it 'includes a GTIN-8 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        it "includes a GTIN-8 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN8) }).to be_truthy
         end
       end
 
       context "with a zero-padded GTIN-12 code" do
         let(:input) { "0123456789012" }
 
-        it 'includes a GTIN-12 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+        it "includes a GTIN-12 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN12) }).to be_truthy
         end
       end
 
       context "when a GTIN-13 code without zero padding" do
         let(:input) { "1234567890128" }
 
-        it 'does not includes a GTIN-8 instance' do
-          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        it "does not includes a GTIN-8 instance" do
+          expect(gtin.to_all_valid.none? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN8) }).to be_truthy
         end
 
-        it 'does not includes a GTIN-12 instance' do
-          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+        it "does not includes a GTIN-12 instance" do
+          expect(gtin.to_all_valid.none? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN12) }).to be_truthy
         end
 
-        it 'includes a GTIN-13 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN13)}).to be_truthy
+        it "includes a GTIN-13 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN13) }).to be_truthy
         end
 
-        it 'includes a zero-padded GTIN-14 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN14)}).to be_truthy
+        it "includes a zero-padded GTIN-14 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN14) }).to be_truthy
         end
       end
     end

--- a/spec/lib/barcodevalidation/gtin/gtin13_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin13_spec.rb
@@ -1,0 +1,43 @@
+require "barcodevalidation/mixin/has_check_digit"
+require "barcodevalidation/mixin/value_object"
+require "barcodevalidation/digit"
+require "barcodevalidation/digit_sequence"
+require "barcodevalidation/gtin"
+
+RSpec.describe BarcodeValidation::GTIN::GTIN13 do
+  subject(:gtin) { described_class.new(input) }
+
+  context "#valid?" do
+    context "whith a valid 8-digit code" do
+      let(:input) { "12345670" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+
+    context "with a valid 12-digit code" do
+      let(:input) { "123456789012" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+
+    context "with a valid 13-digit code" do
+      let(:input) { "1234567890128" }
+
+      it 'is true' do
+        expect(gtin).to be_valid
+      end
+    end
+
+    context "with a valid 14-digit code" do
+      let(:input) { "12345678901231" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/lib/barcodevalidation/gtin/gtin13_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin13_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "barcodevalidation/mixin/has_check_digit"
 require "barcodevalidation/mixin/value_object"
 require "barcodevalidation/digit"

--- a/spec/lib/barcodevalidation/gtin/gtin13_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin13_spec.rb
@@ -40,4 +40,102 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
       end
     end
   end
+
+  context "converstion" do
+    before do
+      expect(gtin.is_a?(described_class)).to be_truthy
+      expect(gtin).to be_valid
+    end
+
+    context "to GTIN-8" do
+      let(:gtin8) { gtin.to_gtin_8 }
+
+      before do
+      end
+
+      context "when prefixed with zeros" do
+        let(:input) { "0000012345670" }
+
+        it 'is valid' do
+          expect(gtin8).to be_valid
+        end
+
+        it 'is a BarcodeValidation::GTIN::GTIN8' do
+          expect(gtin8.is_a?(BarcodeValidation::GTIN::GTIN8)).to be_truthy
+        end
+      end
+
+      context "when not prefixed with zeros" do
+        let(:input) { "1234567890128" }
+
+        it 'is not valid' do
+          expect(gtin8).to_not be_valid
+        end
+
+        it 'is a BarcodeValidation::InvalidGTIN' do
+          expect(gtin8.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+        end
+      end
+    end
+
+    context "to GTIN-12" do
+      let(:gtin12) { gtin.to_gtin_12 }
+
+      context "when prefixed with zeros" do
+        let(:input) { "0123456789012" }
+
+        it 'is valid' do
+          expect(gtin12).to be_valid
+        end
+
+        it 'is a BarcodeValidation::GTIN::GTIN12' do
+          expect(gtin12.is_a?(BarcodeValidation::GTIN::GTIN12)).to be_truthy
+        end
+      end
+
+      context "when not prefixed with zeros" do
+        let(:input) { "1234567890128" }
+
+        it 'is not valid' do
+          expect(gtin12).to_not be_valid
+        end
+
+        it 'is a BarcodeValidation::InvalidGTIN' do
+          expect(gtin12.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+        end
+      end
+    end
+
+    context "to GTIN-13" do
+      let(:input) { "1234567890128" }
+
+      it 'returns itself' do
+        expect(gtin.to_gtin_13).to eq(gtin)
+      end
+    end
+
+    context "to GTIN-14" do
+      let(:gtin14) { gtin.to_gtin_14 }
+
+      before do
+        expect(gtin14.is_a?(BarcodeValidation::GTIN::GTIN14)).to be_truthy
+      end
+
+      context "when prefixed with zeros" do
+        let(:input) { "0123456789012" }
+
+        it 'returns a valid GTIN-14' do
+          expect(gtin14).to be_valid
+        end
+      end
+
+      context "when not prefixed with zeros" do
+        let(:input) { "1234567890128" }
+
+        it 'returns a valid GTIN-14' do
+          expect(gtin14).to be_valid
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/barcodevalidation/gtin/gtin13_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin13_spec.rb
@@ -137,5 +137,43 @@ RSpec.describe BarcodeValidation::GTIN::GTIN13 do
         end
       end
     end
+
+    context "to_all_valid" do
+      context "with a zero-padded GTIN-8 code" do
+        let(:input) { "0000012345670" }
+
+        it 'includes a GTIN-8 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        end
+      end
+
+      context "with a zero-padded GTIN-12 code" do
+        let(:input) { "0123456789012" }
+
+        it 'includes a GTIN-12 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+        end
+      end
+
+      context "when a GTIN-13 code without zero padding" do
+        let(:input) { "1234567890128" }
+
+        it 'does not includes a GTIN-8 instance' do
+          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        end
+
+        it 'does not includes a GTIN-12 instance' do
+          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+        end
+
+        it 'includes a GTIN-13 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN13)}).to be_truthy
+        end
+
+        it 'includes a zero-padded GTIN-14 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN14)}).to be_truthy
+        end
+      end
+    end
   end
 end

--- a/spec/lib/barcodevalidation/gtin/gtin14_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin14_spec.rb
@@ -1,0 +1,43 @@
+require "barcodevalidation/mixin/has_check_digit"
+require "barcodevalidation/mixin/value_object"
+require "barcodevalidation/digit"
+require "barcodevalidation/digit_sequence"
+require "barcodevalidation/gtin"
+
+RSpec.describe BarcodeValidation::GTIN::GTIN14 do
+  subject(:gtin) { described_class.new(input) }
+
+  context "#valid?" do
+    context "whith a valid 8-digit code" do
+      let(:input) { "12345670" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+
+    context "with a valid 12-digit code" do
+      let(:input) { "123456789012" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+
+    context "with a valid 13-digit code" do
+      let(:input) { "1234567890128" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+
+    context "with a valid 14-digit code" do
+      let(:input) { "12345678901231" }
+
+      it 'is true' do
+        expect(gtin).to be_valid
+      end
+    end
+  end
+end

--- a/spec/lib/barcodevalidation/gtin/gtin14_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin14_spec.rb
@@ -40,4 +40,106 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
       end
     end
   end
+
+  context "converstion" do
+    before do
+      expect(gtin.is_a?(described_class)).to be_truthy
+      expect(gtin).to be_valid
+    end
+
+    context "to GTIN-8" do
+      let(:gtin8) { gtin.to_gtin_8 }
+
+      context "when prefixed with zeros" do
+        let(:input) { "00000012345670" }
+
+        it 'is valid' do
+          expect(gtin8).to be_valid
+        end
+
+        it 'is a BarcodeValidation::GTIN::GTIN8' do
+          expect(gtin8.is_a?(BarcodeValidation::GTIN::GTIN8)).to be_truthy
+        end
+      end
+
+      context "when not prefixed with zeros" do
+        let(:input) { "12345678901231" }
+
+        it 'not valid' do
+          expect(gtin8).to_not be_valid
+        end
+
+        it 'is a BarcodeValidation::InvalidGTIN' do
+          expect(gtin8.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+        end
+      end
+    end
+
+    context "to GTIN-12" do
+      let(:gtin12) { gtin.to_gtin_12 }
+
+      context "when prefixed with zeros" do
+        let(:input) { "00123456789012" }
+
+        it 'is valid' do
+          expect(gtin12).to be_valid
+        end
+
+        it 'is a BarcodeValidation::GTIN::GTIN12' do
+          expect(gtin12.is_a?(BarcodeValidation::GTIN::GTIN12)).to be_truthy
+        end
+      end
+
+      context "when not prefixed with zeros" do
+        let(:input) { "12345678901231" }
+
+        it 'is not valid' do
+          expect(gtin12).to_not be_valid
+        end
+
+        it 'is a BarcodeValidation::InvalidGTIN' do
+          expect(gtin12.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+        end
+      end
+    end
+
+    context "to GTIN-13" do
+      let(:gtin13) { gtin.to_gtin_13 }
+
+      before do
+      end
+
+      context "when prefixed with zeros" do
+        let(:input) { "00123456789012" }
+
+        it 'is valid' do
+          expect(gtin13).to be_valid
+        end
+
+        it 'is a BarcodeValidation::GTIN::GTIN13' do
+          expect(gtin13.is_a?(BarcodeValidation::GTIN::GTIN13)).to be_truthy
+        end
+      end
+
+      context "when not prefixed with zeros" do
+        let(:input) { "12345678901231" }
+
+        it 'is not valid' do
+          expect(gtin13).to_not be_valid
+        end
+
+        it 'is a BarcodeValidation::InvalidGTIN' do
+          expect(gtin13.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+        end
+      end
+    end
+
+    context "to GTIN-14" do
+      let(:input) { "12345678901231" }
+
+      it 'returns itself' do
+        expect(gtin.to_gtin_14).to eq(gtin)
+      end
+    end
+  end
 end

--- a/spec/lib/barcodevalidation/gtin/gtin14_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin14_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "barcodevalidation/mixin/has_check_digit"
 require "barcodevalidation/mixin/value_object"
 require "barcodevalidation/digit"

--- a/spec/lib/barcodevalidation/gtin/gtin14_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin14_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
     context "whith a valid 8-digit code" do
       let(:input) { "12345670" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -21,7 +21,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
     context "with a valid 12-digit code" do
       let(:input) { "123456789012" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
     context "with a valid 13-digit code" do
       let(:input) { "1234567890128" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
     context "with a valid 14-digit code" do
       let(:input) { "12345678901231" }
 
-      it 'is true' do
+      it "is true" do
         expect(gtin).to be_valid
       end
     end
@@ -55,11 +55,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
       context "when prefixed with zeros" do
         let(:input) { "00000012345670" }
 
-        it 'is valid' do
+        it "is valid" do
           expect(gtin8).to be_valid
         end
 
-        it 'is a BarcodeValidation::GTIN::GTIN8' do
+        it "is a BarcodeValidation::GTIN::GTIN8" do
           expect(gtin8.is_a?(BarcodeValidation::GTIN::GTIN8)).to be_truthy
         end
       end
@@ -67,11 +67,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
       context "when not prefixed with zeros" do
         let(:input) { "12345678901231" }
 
-        it 'not valid' do
+        it "not valid" do
           expect(gtin8).to_not be_valid
         end
 
-        it 'is a BarcodeValidation::InvalidGTIN' do
+        it "is a BarcodeValidation::InvalidGTIN" do
           expect(gtin8.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
         end
       end
@@ -83,11 +83,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
       context "when prefixed with zeros" do
         let(:input) { "00123456789012" }
 
-        it 'is valid' do
+        it "is valid" do
           expect(gtin12).to be_valid
         end
 
-        it 'is a BarcodeValidation::GTIN::GTIN12' do
+        it "is a BarcodeValidation::GTIN::GTIN12" do
           expect(gtin12.is_a?(BarcodeValidation::GTIN::GTIN12)).to be_truthy
         end
       end
@@ -95,11 +95,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
       context "when not prefixed with zeros" do
         let(:input) { "12345678901231" }
 
-        it 'is not valid' do
+        it "is not valid" do
           expect(gtin12).to_not be_valid
         end
 
-        it 'is a BarcodeValidation::InvalidGTIN' do
+        it "is a BarcodeValidation::InvalidGTIN" do
           expect(gtin12.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
         end
       end
@@ -114,11 +114,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
       context "when prefixed with zeros" do
         let(:input) { "00123456789012" }
 
-        it 'is valid' do
+        it "is valid" do
           expect(gtin13).to be_valid
         end
 
-        it 'is a BarcodeValidation::GTIN::GTIN13' do
+        it "is a BarcodeValidation::GTIN::GTIN13" do
           expect(gtin13.is_a?(BarcodeValidation::GTIN::GTIN13)).to be_truthy
         end
       end
@@ -126,11 +126,11 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
       context "when not prefixed with zeros" do
         let(:input) { "12345678901231" }
 
-        it 'is not valid' do
+        it "is not valid" do
           expect(gtin13).to_not be_valid
         end
 
-        it 'is a BarcodeValidation::InvalidGTIN' do
+        it "is a BarcodeValidation::InvalidGTIN" do
           expect(gtin13.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
         end
       end
@@ -139,7 +139,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
     context "to GTIN-14" do
       let(:input) { "12345678901231" }
 
-      it 'returns itself' do
+      it "returns itself" do
         expect(gtin.to_gtin_14).to eq(gtin)
       end
     end
@@ -148,44 +148,44 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
       context "with a zero-padded GTIN-8 code" do
         let(:input) { "00000012345670" }
 
-        it 'includes a GTIN-8 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        it "includes a GTIN-8 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN8) }).to be_truthy
         end
       end
 
       context "with a zero-padded GTIN-12 code" do
         let(:input) { "00123456789012" }
 
-        it 'includes a GTIN-12 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+        it "includes a GTIN-12 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN12) }).to be_truthy
         end
       end
 
       context "with a zero-padded GTIN-13 code" do
         let(:input) { "01234567890128" }
 
-        it 'includes a GTIN-13 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN13)}).to be_truthy
+        it "includes a GTIN-13 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN13) }).to be_truthy
         end
       end
 
       context "when a GTIN-14 code without zero padding" do
         let(:input) { "12345678901231" }
 
-        it 'does not includes a GTIN-8 instance' do
-          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        it "does not includes a GTIN-8 instance" do
+          expect(gtin.to_all_valid.none? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN8) }).to be_truthy
         end
 
-        it 'does not includes a GTIN-12 instance' do
-          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+        it "does not includes a GTIN-12 instance" do
+          expect(gtin.to_all_valid.none? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN12) }).to be_truthy
         end
 
-        it 'does not include a GTIN-13 instance' do
-          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN13)}).to be_truthy
+        it "does not include a GTIN-13 instance" do
+          expect(gtin.to_all_valid.none? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN13) }).to be_truthy
         end
 
-        it 'includes a GTIN-14 instance' do
-          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN14)}).to be_truthy
+        it "includes a GTIN-14 instance" do
+          expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN14) }).to be_truthy
         end
       end
     end

--- a/spec/lib/barcodevalidation/gtin/gtin14_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin14_spec.rb
@@ -141,5 +141,51 @@ RSpec.describe BarcodeValidation::GTIN::GTIN14 do
         expect(gtin.to_gtin_14).to eq(gtin)
       end
     end
+
+    context "to_all_valid" do
+      context "with a zero-padded GTIN-8 code" do
+        let(:input) { "00000012345670" }
+
+        it 'includes a GTIN-8 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        end
+      end
+
+      context "with a zero-padded GTIN-12 code" do
+        let(:input) { "00123456789012" }
+
+        it 'includes a GTIN-12 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+        end
+      end
+
+      context "with a zero-padded GTIN-13 code" do
+        let(:input) { "01234567890128" }
+
+        it 'includes a GTIN-13 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN13)}).to be_truthy
+        end
+      end
+
+      context "when a GTIN-14 code without zero padding" do
+        let(:input) { "12345678901231" }
+
+        it 'does not includes a GTIN-8 instance' do
+          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+        end
+
+        it 'does not includes a GTIN-12 instance' do
+          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+        end
+
+        it 'does not include a GTIN-13 instance' do
+          expect(gtin.to_all_valid.none? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN13)}).to be_truthy
+        end
+
+        it 'includes a GTIN-14 instance' do
+          expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN14)}).to be_truthy
+        end
+      end
+    end
   end
 end

--- a/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
@@ -94,8 +94,14 @@ RSpec.describe BarcodeValidation::GTIN::GTIN8 do
     end
 
     context "to_all_valid" do
+      let(:includes_gtin8) do
+        gtin.to_all_valid.any? do |code|
+          code.is_a?(BarcodeValidation::GTIN::GTIN8)
+        end
+      end
+
       it "includes a GTIN-8 instance" do
-        expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN8) }).to be_truthy
+        expect(includes_gtin8).to be_truthy
       end
 
       it "includes a GTIN-12 instance" do

--- a/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
@@ -1,0 +1,43 @@
+require "barcodevalidation/mixin/has_check_digit"
+require "barcodevalidation/mixin/value_object"
+require "barcodevalidation/digit"
+require "barcodevalidation/digit_sequence"
+require "barcodevalidation/gtin"
+
+RSpec.describe BarcodeValidation::GTIN::GTIN8 do
+  subject(:gtin) { described_class.new(input) }
+
+  context "#valid?" do
+    context "whith a valid 8-digit code" do
+      let(:input) { "12345670" }
+
+      it 'is true' do
+        expect(gtin).to be_valid
+      end
+    end
+
+    context "with a valid 12-digit code" do
+      let(:input) { "123456789012" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+
+    context "with a valid 13-digit code" do
+      let(:input) { "1234567890128" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+
+    context "with a valid 14-digit code" do
+      let(:input) { "12345678901231" }
+
+      it 'is false' do
+        expect(gtin).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN8 do
     context "whith a valid 8-digit code" do
       let(:input) { "12345670" }
 
-      it 'is true' do
+      it "is true" do
         expect(gtin).to be_valid
       end
     end
@@ -21,7 +21,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN8 do
     context "with a valid 12-digit code" do
       let(:input) { "123456789012" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN8 do
     context "with a valid 13-digit code" do
       let(:input) { "1234567890128" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN8 do
     context "with a valid 14-digit code" do
       let(:input) { "12345678901231" }
 
-      it 'is false' do
+      it "is false" do
         expect(gtin).to_not be_valid
       end
     end
@@ -52,7 +52,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN8 do
     end
 
     context "to GTIN-8" do
-      it 'returns itself' do
+      it "returns itself" do
         expect(gtin.to_gtin_8).to eq(gtin)
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN8 do
         expect(gtin12.is_a?(BarcodeValidation::GTIN::GTIN12)).to be_truthy
       end
 
-      it 'returns a valid GTIN-12' do
+      it "returns a valid GTIN-12" do
         expect(gtin12).to be_valid
       end
     end
@@ -76,7 +76,7 @@ RSpec.describe BarcodeValidation::GTIN::GTIN8 do
         expect(gtin13.is_a?(BarcodeValidation::GTIN::GTIN13)).to be_truthy
       end
 
-      it 'returns a valid GTIN-13' do
+      it "returns a valid GTIN-13" do
         expect(gtin13).to be_valid
       end
     end
@@ -88,26 +88,26 @@ RSpec.describe BarcodeValidation::GTIN::GTIN8 do
         expect(gtin14.is_a?(BarcodeValidation::GTIN::GTIN14)).to be_truthy
       end
 
-      it 'returns a valid GTIN-14' do
+      it "returns a valid GTIN-14" do
         expect(gtin14).to be_valid
       end
     end
 
     context "to_all_valid" do
-      it 'includes a GTIN-8 instance' do
-        expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+      it "includes a GTIN-8 instance" do
+        expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN8) }).to be_truthy
       end
 
-      it 'includes a GTIN-12 instance' do
-        expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+      it "includes a GTIN-12 instance" do
+        expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN12) }).to be_truthy
       end
 
-      it 'includes a GTIN-13 instance' do
-        expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN13)}).to be_truthy
+      it "includes a GTIN-13 instance" do
+        expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN13) }).to be_truthy
       end
 
-      it 'includes a GTIN-14 instance' do
-        expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN14)}).to be_truthy
+      it "includes a GTIN-14 instance" do
+        expect(gtin.to_all_valid.any? { |code| code.is_a?(BarcodeValidation::GTIN::GTIN14) }).to be_truthy
       end
     end
   end

--- a/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
@@ -90,5 +90,23 @@ RSpec.describe BarcodeValidation::GTIN::GTIN8 do
         expect(gtin14).to be_valid
       end
     end
+
+    context "to_all_valid" do
+      it 'includes a GTIN-8 instance' do
+        expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN8)}).to be_truthy
+      end
+
+      it 'includes a GTIN-12 instance' do
+        expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN12)}).to be_truthy
+      end
+
+      it 'includes a GTIN-13 instance' do
+        expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN13)}).to be_truthy
+      end
+
+      it 'includes a GTIN-14 instance' do
+        expect(gtin.to_all_valid.any? {|code| code.is_a?(BarcodeValidation::GTIN::GTIN14)}).to be_truthy
+      end
+    end
   end
 end

--- a/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "barcodevalidation/mixin/has_check_digit"
 require "barcodevalidation/mixin/value_object"
 require "barcodevalidation/digit"

--- a/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/gtin8_spec.rb
@@ -40,4 +40,55 @@ RSpec.describe BarcodeValidation::GTIN::GTIN8 do
       end
     end
   end
+
+  context "converstion" do
+    let(:input) { "12345670" }
+
+    before do
+      expect(gtin.is_a?(described_class)).to be_truthy
+      expect(gtin).to be_valid
+    end
+
+    context "to GTIN-8" do
+      it 'returns itself' do
+        expect(gtin.to_gtin_8).to eq(gtin)
+      end
+    end
+
+    context "to GTIN-12" do
+      let(:gtin12) { gtin.to_gtin_12 }
+
+      before do
+        expect(gtin12.is_a?(BarcodeValidation::GTIN::GTIN12)).to be_truthy
+      end
+
+      it 'returns a valid GTIN-12' do
+        expect(gtin12).to be_valid
+      end
+    end
+
+    context "to GTIN-13" do
+      let(:gtin13) { gtin.to_gtin_13 }
+
+      before do
+        expect(gtin13.is_a?(BarcodeValidation::GTIN::GTIN13)).to be_truthy
+      end
+
+      it 'returns a valid GTIN-13' do
+        expect(gtin13).to be_valid
+      end
+    end
+
+    context "to GTIN-14" do
+      let(:gtin14) { gtin.to_gtin_14 }
+
+      before do
+        expect(gtin14.is_a?(BarcodeValidation::GTIN::GTIN14)).to be_truthy
+      end
+
+      it 'returns a valid GTIN-14' do
+        expect(gtin14).to be_valid
+      end
+    end
+  end
 end

--- a/spec/lib/barcodevalidation/gtin_spec.rb
+++ b/spec/lib/barcodevalidation/gtin_spec.rb
@@ -54,13 +54,17 @@ RSpec.describe BarcodeValidation::GTIN do
 
       context "for a code that is not zero-padded" do
         let(:input) { "123456789012" }
+        let(:error_message) do
+          "invalid value for BarcodeValidation::GTIN::GTIN8(): #{input.inspect}"
+        end
+        let(:is_an_invalid_gtin) { gtin8.is_a?(BarcodeValidation::InvalidGTIN) }
 
         it "returns a BarcodeValidation::InvalidGTIN instance" do
-          expect(gtin8.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+          expect(is_an_invalid_gtin).to be_truthy
         end
 
         it "has a meaningful error message" do
-          expect(gtin8.error_message).to eq("invalid value for BarcodeValidation::GTIN::GTIN8(): #{input.inspect}")
+          expect(gtin8.error_message).to eq(error_message)
         end
       end
     end

--- a/spec/lib/barcodevalidation/gtin_spec.rb
+++ b/spec/lib/barcodevalidation/gtin_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe BarcodeValidation::GTIN do
   end
 
   describe "sequence methods" do
-    let(:input) { 123 }
+    let(:input) { 12345678 }
     subject(:sequence) { gtin.reverse }
     it { is_expected.to_not be_a described_class }
   end

--- a/spec/lib/barcodevalidation/gtin_spec.rb
+++ b/spec/lib/barcodevalidation/gtin_spec.rb
@@ -40,6 +40,48 @@ RSpec.describe BarcodeValidation::GTIN do
     it { is_expected.to_not be_a described_class }
   end
 
+  describe "factory interface" do
+    context "for 8-digit input" do
+      let(:input) { "12345678" }
+
+      it 'constructs a BarcodeValidation::GTIN::GTIN8' do
+        expect(gtin.is_a?(BarcodeValidation::GTIN::GTIN8)).to be_truthy
+      end
+    end
+
+    context "for 12-digit input" do
+      let(:input) { "123456789012" }
+
+      it 'constructs a BarcodeValidation::GTIN::GTIN12' do
+        expect(gtin.is_a?(BarcodeValidation::GTIN::GTIN12)).to be_truthy
+      end
+    end
+
+    context "for 13-digit input" do
+      let(:input) { "1234567890123" }
+
+      it 'constructs a BarcodeValidation::GTIN::GTIN13' do
+        expect(gtin.is_a?(BarcodeValidation::GTIN::GTIN13)).to be_truthy
+      end
+    end
+
+    context "for 14-digit input" do
+      let(:input) { "12345678901234" }
+
+      it 'constructs a BarcodeValidation::GTIN::GTIN14' do
+        expect(gtin.is_a?(BarcodeValidation::GTIN::GTIN14)).to be_truthy
+      end
+    end
+
+    context "for non-standard input length" do
+      let(:input) { "1234" }
+
+      it 'constructs a BarcodeValidation::InvalidGTIN' do
+        expect(gtin.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+      end
+    end
+  end
+
   describe "conversion" do
     context "when converting from a superset down to a subset" do
       let(:gtin8) { gtin.to_gtin_8 }

--- a/spec/lib/barcodevalidation/gtin_spec.rb
+++ b/spec/lib/barcodevalidation/gtin_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe BarcodeValidation::GTIN do
   end
 
   describe "sequence methods" do
-    let(:input) { 12345678 }
+    let(:input) { 12_345_678 }
     subject(:sequence) { gtin.reverse }
     it { is_expected.to_not be_a described_class }
   end
@@ -47,7 +47,7 @@ RSpec.describe BarcodeValidation::GTIN do
       context "for a zero-padded code" do
         let(:input) { "000012345670" }
 
-        it 'returns an instance of the concrete class for that subset' do
+        it "returns an instance of the concrete class for that subset" do
           expect(gtin8.is_a?(BarcodeValidation::GTIN::GTIN8)).to be_truthy
         end
       end
@@ -55,11 +55,11 @@ RSpec.describe BarcodeValidation::GTIN do
       context "for a code that is not zero-padded" do
         let(:input) { "123456789012" }
 
-        it 'returns a BarcodeValidation::InvalidGTIN instance' do
+        it "returns a BarcodeValidation::InvalidGTIN instance" do
           expect(gtin8.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
         end
 
-        it 'has a meaningful error message' do
+        it "has a meaningful error message" do
           expect(gtin8.error_message).to eq("invalid value for BarcodeValidation::GTIN::GTIN8(): #{input.inspect}")
         end
       end

--- a/spec/lib/barcodevalidation/gtin_spec.rb
+++ b/spec/lib/barcodevalidation/gtin_spec.rb
@@ -39,4 +39,30 @@ RSpec.describe BarcodeValidation::GTIN do
     subject(:sequence) { gtin.reverse }
     it { is_expected.to_not be_a described_class }
   end
+
+  describe "conversion" do
+    context "when converting from a superset down to a subset" do
+      let(:gtin8) { gtin.to_gtin_8 }
+
+      context "for a zero-padded code" do
+        let(:input) { "000012345670" }
+
+        it 'returns an instance of the concrete class for that subset' do
+          expect(gtin8.is_a?(BarcodeValidation::GTIN::GTIN8)).to be_truthy
+        end
+      end
+
+      context "for a code that is not zero-padded" do
+        let(:input) { "123456789012" }
+
+        it 'returns a BarcodeValidation::InvalidGTIN instance' do
+          expect(gtin8.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+        end
+
+        it 'has a meaningful error message' do
+          expect(gtin8.error_message).to eq("invalid value for BarcodeValidation::GTIN::GTIN8(): #{input.inspect}")
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/barcodevalidation/gtin_spec.rb
+++ b/spec/lib/barcodevalidation/gtin_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe BarcodeValidation::GTIN do
     context "for 8-digit input" do
       let(:input) { "12345678" }
 
-      it 'constructs a BarcodeValidation::GTIN::GTIN8' do
+      it "constructs a BarcodeValidation::GTIN::GTIN8" do
         expect(gtin.is_a?(BarcodeValidation::GTIN::GTIN8)).to be_truthy
       end
     end
@@ -52,7 +52,7 @@ RSpec.describe BarcodeValidation::GTIN do
     context "for 12-digit input" do
       let(:input) { "123456789012" }
 
-      it 'constructs a BarcodeValidation::GTIN::GTIN12' do
+      it "constructs a BarcodeValidation::GTIN::GTIN12" do
         expect(gtin.is_a?(BarcodeValidation::GTIN::GTIN12)).to be_truthy
       end
     end
@@ -60,7 +60,7 @@ RSpec.describe BarcodeValidation::GTIN do
     context "for 13-digit input" do
       let(:input) { "1234567890123" }
 
-      it 'constructs a BarcodeValidation::GTIN::GTIN13' do
+      it "constructs a BarcodeValidation::GTIN::GTIN13" do
         expect(gtin.is_a?(BarcodeValidation::GTIN::GTIN13)).to be_truthy
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe BarcodeValidation::GTIN do
     context "for 14-digit input" do
       let(:input) { "12345678901234" }
 
-      it 'constructs a BarcodeValidation::GTIN::GTIN14' do
+      it "constructs a BarcodeValidation::GTIN::GTIN14" do
         expect(gtin.is_a?(BarcodeValidation::GTIN::GTIN14)).to be_truthy
       end
     end
@@ -76,7 +76,7 @@ RSpec.describe BarcodeValidation::GTIN do
     context "for non-standard input length" do
       let(:input) { "1234" }
 
-      it 'constructs a BarcodeValidation::InvalidGTIN' do
+      it "constructs a BarcodeValidation::InvalidGTIN" do
         expect(gtin.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
       end
     end

--- a/spec/lib/barcodevalidation_spec.rb
+++ b/spec/lib/barcodevalidation_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe BarcodeValidation do
     Class.new,
     Object.new,
     0...10,
+    /abcd/,
   ].freeze
 
   describe ".scan" do

--- a/spec/lib/barcodevalidation_spec.rb
+++ b/spec/lib/barcodevalidation_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe BarcodeValidation do
     Class.new,
     Object.new,
     0...10,
-    /abcd/,
   ].freeze
 
   describe ".scan" do


### PR DESCRIPTION
Dependency for marketplacer/marketplacer#20482

Depends on #4 for updated rubocop settings

Can tell GTIN objects to convert themselves into different formats, while applying validation rules around the code length and check-bit that handle zero-padding.

There are 4 [GTIN standards](https://www.gtin.info) corresponding to the code length:

* GTIN-8
* GTIN-12
* GTIN-13
* GTIN-14

It is valid to convert a subset up to a superset by prefixing it with a zero.

For example, a GTIN-8 code of 12345670 can be represented as a GTIN-12 code of 00001234567.

A superset can be converted back to a subset, only when it is a zero-padded representation. For example, a GTIN-12 code of 00001234567 can be converted back to a GTIN-8 code of 12345670, but a GTIN-12 code of 123445678907 cannot.

## Factory interface

The current public interface to `BarcodeValidation.scan` is maintained, while using a template class structure to return an instance of the GTIN class matching the given barcode's length:

```ruby
gtin = BarcodeValidation.scan("12345670")
=> #<BarcodeValidation::GTIN::GTIN8(12345670)>

gtin.valid?
=> true
```

## Conversion between formats

All GTIN objects provide public instance methods to explicitly convert themselves into one of the 4 GTIN formats:

* `to_gtin_8`
* `to_gtin_12`
* `to_gtin_13`
* `to_gtin_14`

If the GTIN can be converted into that format by either zero-padding, or removing leading zeros, it will return a valid instance of the corresponding GTIN class:

```ruby
gtin = BarcodeValidation.scan("00001234567")
=> #<BarcodeValidation::GTIN::GTIN12(00001234567)>

gtin8 = gtin.to_gtin_8
=> #<BarcodeValidation::GTIN::GTIN8(12345670)>

gtin8.valid?
=> true
```

If it cannot be converted into the given format, it will return a `BarcodeValidation::InvalidGTIN` instance:

```ruby
gtin = BarcodeValidation.scan("123456789012")
=> #<BarcodeValidation::GTIN::GTIN13(123456789012)>

gtin8 = gtin.to_gtin_8
=> #<BarcodeValidation::InvalidGTIN input="123456789012" error="invalid value for BarcodeValidation::GTIN::GTIN8(): "123456789012"">

gtin8.valid?
=> false

gtin8.error_message
=> "invalid value for BarcodeValidation::GTIN::GTIN8(): \"123456789012\""
```

### Converting to all valid formats with `to_all_valid`

For DB lookups in the Marketplacer app, GTIN objects provide the `to_all_valid` method, which returns a collection of GTIN objects for valid formats that the code can be converted into. For example, a GTIN-13 code that is a zero-padded GTIN-12 can be converted down to GTIN-12, and up to GTIN-14, but not down to GTIN-8:

```
gtin = BarcodeValidation.scan("0123456789012")
=> #<BarcodeValidation::GTIN::GTIN13(123456789012)>

gtin.to_all_valid
=> [
  #<BarcodeValidation::GTIN::GTIN12(123456789012)>,
  #<BarcodeValidation::GTIN::GTIN13(0123456789012)>,
  #<BarcodeValidation::GTIN::GTIN14(00123456789012)>
]
```
