### PR TITLE
Fix(conversion): consistent interface for invalid GTINs

### DIFF
--- a/lib/barcodevalidation/invalid_gtin.rb
+++ b/lib/barcodevalidation/invalid_gtin.rb
@@ -22,5 +22,25 @@ module BarcodeValidation
 
       @error.inspect
     end
+
+    def to_all_valid
+      []
+    end
+
+    def to_gtin_8
+      self
+    end
+
+    def to_gtin_12
+      self
+    end
+
+    def to_gtin_13
+      self
+    end
+
+    def to_gtin_14
+      self
+    end
   end
 end

--- a/spec/lib/barcodevalidation/invalid_gtin_spec.rb
+++ b/spec/lib/barcodevalidation/invalid_gtin_spec.rb
@@ -20,4 +20,50 @@ RSpec.describe BarcodeValidation::InvalidGTIN do
     it { is_expected.to_not be_a described_class }
     it { is_expected.to eq "TUPNI" }
   end
+
+  describe "#to_all_valid" do
+    it "is an empty array" do
+      expect(subject.to_all_valid).to eq([])
+    end
+  end
+
+  describe "#to_gtin_8" do
+    it "returns itself" do
+      expect(subject.to_gtin_8).to eq(subject)
+    end
+
+    it "is not valid" do
+      expect(subject.to_gtin_8).to_not be_valid
+    end
+  end
+
+  describe "#to_gtin_12" do
+    it "returns itself" do
+      expect(subject.to_gtin_12).to eq(subject)
+    end
+
+    it "is not valid" do
+      expect(subject.to_gtin_8).to_not be_valid
+    end
+  end
+
+  describe "#to_gtin_13" do
+    it "returns itself" do
+      expect(subject.to_gtin_13).to eq(subject)
+    end
+
+    it "is not valid" do
+      expect(subject.to_gtin_8).to_not be_valid
+    end
+  end
+
+  describe "#to_gtin_14" do
+    it "returns itself" do
+      expect(subject.to_gtin_14).to eq(subject)
+    end
+
+    it "is not valid" do
+      expect(subject.to_gtin_8).to_not be_valid
+    end
+  end
 end

--- a/spec/lib/barcodevalidation_spec.rb
+++ b/spec/lib/barcodevalidation_spec.rb
@@ -104,5 +104,41 @@ RSpec.describe BarcodeValidation do
         expect(realtime / valid_inputs.count).to be < 0.000_05 # 50us
       end
     end
+
+    describe "conversion" do
+      context "for an invalid barcode" do
+        let(:input) { "123456" }
+
+        context "#to_all_valid" do
+          it "is an empty array" do
+            expect(subject.to_all_valid).to eq([])
+          end
+        end
+
+        context "#to_gtin_8" do
+          it "is a BarcodeValidation::InvalidGTIN" do
+            expect(subject.to_gtin_8.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+          end
+        end
+
+        context "#to_gtin_12" do
+          it "is a BarcodeValidation::InvalidGTIN" do
+            expect(subject.to_gtin_12.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+          end
+        end
+
+        context "#to_gtin_13" do
+          it "is a BarcodeValidation::InvalidGTIN" do
+            expect(subject.to_gtin_13.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+          end
+        end
+
+        context "#to_gtin_14" do
+          it "is a BarcodeValidation::InvalidGTIN" do
+            expect(subject.to_gtin_14.is_a?(BarcodeValidation::InvalidGTIN)).to be_truthy
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Attempting to convert an invalid GTIN into other formats should return an invalid GTIN object instead of raising a NoMethodError exception.

Resolves #5
