### PR TITLE
ci: switch to Buildkite

### DIFF
--- a/.buildkite/docker/Dockerfile
+++ b/.buildkite/docker/Dockerfile
@@ -1,0 +1,12 @@
+ARG RUBY_VERSION=2.6
+FROM ruby:${RUBY_VERSION}-alpine
+WORKDIR /app
+
+RUN apk --update add --no-cache \
+  bash \
+  grep
+RUN gem install bundler
+
+COPY . ./
+
+RUN ./bin/setup

--- a/.buildkite/docker/docker-compose.yml
+++ b/.buildkite/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  test:
+    build:
+      dockerfile: '.buildkite/docker/Dockerfile'
+      context: '../../'
+    command: ["bin/rake"]
+  node:
+    build:
+      dockerfile: '.buildkite/docker/node.Dockerfile'
+      context: '../../'
+    volumes:
+      - ../../:/app
+      - /app/node_modules

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,16 @@
+---
+steps:
+  - name: ':ruby: 2.5 tests'
+    plugins:
+      - docker-compose#v3.7.0:
+          config: .buildkite/docker/docker-compose.yml
+          run: test
+          args:
+            RUBY_VERSION=2.5
+  - name: ':ruby: 2.6 tests'
+    plugins:
+      - docker-compose#v3.7.0:
+          config: .buildkite/docker/docker-compose.yml
+          run: test
+          args:
+            RUBY_VERSION=2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 2.5
-  - 2.6
-script:
-  - gem install bundler
-  - bin/setup
-  - bin/rake


### PR DESCRIPTION
We use it for all our things, so we'd like to keep a consistent approach
across all our repositories instead of having to manage access to yet
another service.

**Steps to test that this is working:**

1. Look at Buildkite
