### PR TITLE
chore(build): also test with rubies 2.7, 3.0 and 3.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,27 @@ steps:
           run: test
           args:
             RUBY_VERSION=2.6
+  - name: ':ruby: 2.7 tests'
+    plugins:
+      - docker-compose#v3.7.0:
+          config: .buildkite/docker/docker-compose.yml
+          run: test
+          args:
+            RUBY_VERSION=2.7
+  - name: ':ruby: 3.0 tests'
+    plugins:
+      - docker-compose#v3.7.0:
+          config: .buildkite/docker/docker-compose.yml
+          run: test
+          args:
+            RUBY_VERSION=3.0
+  - name: ':ruby: 3.1 tests'
+    plugins:
+      - docker-compose#v3.7.0:
+          config: .buildkite/docker/docker-compose.yml
+          run: test
+          args:
+            RUBY_VERSION=3.1
   - name: ':git: Lint commits'
     command: 'yarn run lint:commits:branch'
     # we don't modify main commits, so it's too late to lint here

--- a/barcodevalidation.gemspec
+++ b/barcodevalidation.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "barcodevalidation/version"
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = "~> 2.5"
+  spec.required_ruby_version = ">= 2.5"
   spec.name          = "barcodevalidation"
   spec.version       = BarcodeValidation::VERSION
   spec.authors       = ["Marketplacer"]

--- a/barcodevalidation.gemspec
+++ b/barcodevalidation.gemspec
@@ -24,6 +24,4 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files
                            .grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  spec.add_runtime_dependency "adamantium"
 end

--- a/lib/barcodevalidation/digit.rb
+++ b/lib/barcodevalidation/digit.rb
@@ -5,7 +5,6 @@ require_relative "error/argument_error_class"
 
 module BarcodeValidation
   class Digit < DelegateClass(Integer)
-    include Adamantium
     include Mixin::ValueObject
 
     INTEGER_CAST_ERRORS = [::ArgumentError, ::TypeError].freeze

--- a/lib/barcodevalidation/digit_sequence.rb
+++ b/lib/barcodevalidation/digit_sequence.rb
@@ -6,7 +6,6 @@ require_relative "error/argument_error_class"
 module BarcodeValidation
   class DigitSequence < Array
     extend Forwardable
-    include Adamantium::Flat
     include Mixin::ValueObject
 
     delegate to_s: :join
@@ -30,6 +29,10 @@ module BarcodeValidation
       when String, Numeric then super(self.class.new(other))
       else super
       end
+    end
+
+    def *(other)
+      self.class.new(super)
     end
 
     ArgumentError = Error::ArgumentErrorClass.new(DigitSequence)

--- a/lib/barcodevalidation/gtin/check_digit.rb
+++ b/lib/barcodevalidation/gtin/check_digit.rb
@@ -3,7 +3,6 @@
 module BarcodeValidation
   module GTIN
     class CheckDigit < DelegateClass(Digit)
-      include Adamantium::Flat
       include Mixin::ValueObject
 
       attr_reader :actual, :expected

--- a/lib/barcodevalidation/mixin/value_object.rb
+++ b/lib/barcodevalidation/mixin/value_object.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "adamantium"
-
 module BarcodeValidation
   module Mixin
     module ValueObject
@@ -10,10 +8,6 @@ module BarcodeValidation
       end
 
       module ClassMethods
-        # Memoizes return values based on the inputs
-        def new(*args)
-          (@__new_cache ||= {})[args] ||= super
-        end
       end
 
       def eql?(other)

--- a/spec/lib/barcodevalidation/digit_sequence_spec.rb
+++ b/spec/lib/barcodevalidation/digit_sequence_spec.rb
@@ -26,25 +26,19 @@ RSpec.describe BarcodeValidation::DigitSequence do
     context "with an equivalent sequence" do
       let(:other_input) { input }
       it { is_expected.to eq other }
-      it { is_expected.to eql other }
       its(:hash) { is_expected.to eq other.hash }
-      its(:object_id) { is_expected.to eq other.object_id }
     end
 
     context "with a different sequence" do
       let(:other_input) { 987_654 }
       it { is_expected.to_not eq other }
-      it { is_expected.to_not eql other }
       its(:hash) { is_expected.to_not eq other.hash }
-      its(:object_id) { is_expected.to_not eq other.object_id }
     end
 
     context "when the other is unrelated" do
       let(:other) { false }
       it { is_expected.to_not eq other }
-      it { is_expected.to_not eql other }
       its(:hash) { is_expected.to_not eq other.hash }
-      its(:object_id) { is_expected.to_not eq other.object_id }
     end
   end
 

--- a/spec/lib/barcodevalidation/digit_spec.rb
+++ b/spec/lib/barcodevalidation/digit_spec.rb
@@ -8,48 +8,20 @@ RSpec.describe BarcodeValidation::Digit do
   subject(:digit) { described_class.new(input) }
   let(:input) { 9 }
 
-  describe "#initialize" do
-    it "caches equivalent instances" do
-      expect(described_class.new(1)).to be described_class.new(1)
-    end
-
-    context "after creating many instances" do
-      before { inputs.each { |input| described_class.new(input) } }
-      let(:inputs) do
-        [
-          %w[1 2 3 4 5 6 7 8 9 0],
-          1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
-          described_class.new(1), described_class.new(2)
-        ].flatten
-      end
-
-      subject(:every_instance) do
-        cache = described_class.instance_variable_get(:@__new_cache)
-        (cache || {}).values
-      end
-
-      its(:count) { is_expected.to be <= 100 }
-    end
-  end
-
   context "in comparison to another digit" do
     let(:other_digit) { described_class.new(other_input) }
 
     context "with an equivalent digit" do
       let(:other_input) { input }
       it { is_expected.to eq other_digit }
-      it { is_expected.to eql other_digit }
       its(:hash) { is_expected.to eq other_digit.hash }
-      its(:object_id) { is_expected.to eq other_digit.object_id }
       its(:inspect) { is_expected.to eq other_digit.inspect }
     end
 
     context "with a different digit" do
       let(:other_input) { 8 }
       it { is_expected.to_not eq other_digit }
-      it { is_expected.to_not eql other_digit }
       its(:hash) { is_expected.to_not eq other_digit.hash }
-      its(:object_id) { is_expected.to_not eq other_digit.object_id }
       its(:inspect) { is_expected.to_not eq other_digit.inspect }
     end
   end
@@ -57,7 +29,6 @@ RSpec.describe BarcodeValidation::Digit do
   context "with a valid value" do
     let(:input) { 3 }
     it { is_expected.to be_an_instance_of described_class }
-    it { is_expected.to be_frozen }
     it { is_expected.to eq 3 }
     it { is_expected.to_not eq 2 }
     its(:to_s) { is_expected.to eq "3" }
@@ -67,7 +38,6 @@ RSpec.describe BarcodeValidation::Digit do
   context "with a floating-point value" do
     let(:input) { 8.5 }
     it { is_expected.to be_an_instance_of described_class }
-    it { is_expected.to be_frozen }
     it { is_expected.to eq 8 }
     it { is_expected.to_not eq 9 }
     its(:to_s) { is_expected.to eq "8" }

--- a/spec/lib/barcodevalidation/gtin/check_digit_spec.rb
+++ b/spec/lib/barcodevalidation/gtin/check_digit_spec.rb
@@ -12,12 +12,10 @@ RSpec.describe BarcodeValidation::GTIN::CheckDigit do
     let(:input) { 1 }
 
     it { is_expected.to eq 1 }
-    it { is_expected.to be_frozen }
     it { is_expected.to be_valid }
     its(:to_s) { is_expected.to eq "1" }
     its(:actual) { is_expected.to eq 1 }
     its(:expected) { is_expected.to eq 1 }
-    its(:dup) { is_expected.to be subject }
     its(:inspect) { is_expected.to eq "#<#{described_class}(1)>" }
     its("actual.inspect") { is_expected.to eq digit.expected.inspect }
   end
@@ -28,12 +26,10 @@ RSpec.describe BarcodeValidation::GTIN::CheckDigit do
     let(:expected) { 1 }
 
     it { is_expected.to eq 2 }
-    it { is_expected.to be_frozen }
     it { is_expected.to_not be_valid }
     its(:to_s) { is_expected.to eq "2" }
     its(:actual) { is_expected.to eq 2 }
     its(:expected) { is_expected.to eq 1 }
-    its(:dup) { is_expected.to be subject }
 
     describe "#inspect" do
       subject(:result) { digit.inspect }


### PR DESCRIPTION
Test with the ruby versions that have come out since the last time we touched this

update: Also fix to work with ruby 3+

**Release Checklist:**
- [x] Authentication is on point (you are who you say you are)
- [x] Authorisation is on point (you are allowed to access this)
- [x] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [x] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [x] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [x] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
- [x] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Tettra Docs, Postman Collection, Lucid Charts, and your PM knows what's up.
