### PR TITLE
Fix: re-expose GTIN#check_digit as public method

### DIFF
--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -56,11 +56,11 @@ module BarcodeValidation
         is_a?(GTIN14) ? self : transcode_to(GTIN14)
       end
 
-      private
-
       def check_digit
         CheckDigit.new(last, expected: expected_check_digit)
       end
+
+      private
 
       def expected_check_digit
         (MODULUS - weighted_checkable_digit_sum) % MODULUS

--- a/spec/lib/barcodevalidation/gtin_spec.rb
+++ b/spec/lib/barcodevalidation/gtin_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe BarcodeValidation::GTIN do
   context "with a UPC with an invalid check digit" do
     let(:input) { 123_456_789_011 }
     it { is_expected.to_not be_valid }
+
+    it "exposes the CheckDigit" do
+      expect(gtin.check_digit).to_not be_valid
+    end
   end
 
   context "with a sequence of digits of unknown length" do


### PR DESCRIPTION
Restore `BarcodeValiation::GTIN#check_digit` as public method (broken in v2.3.0).

PR #3 changed the internals of BarcodeValidation::GTIN to support different GTIN formats and to allow conversion between them. While this is a _very_ nice feature, it unfortunately made the previously public method `GTIN#check_digit` (which was added via BarcodeValidation::Mixin) private.

In v2.2.0 we relied on this in our tests to fix the check digit of randomly generated barcodes. v2.3.0 makes both `check_digit` and `expected_check_digit` private, so it does not publicly expose any of the tools we'd need for our purposes.

The simplest fix seemed to make `check_digit` public, which restores the API that was available in v2.2.0. I've added a spec that calls the method and its validation as a means to ensure it remains public.

The readme still references `check_digit` as a public method, which reinforces that it was probably made private by accident.

(Note that I read the commit template, but it seems copy/pasted from another project that has interface tests and authentication. I did try to keep the first paragraph of my PR suitable for a changelog, because I'm not sure if that _is_ relevant or not.)