### PR TITLE
Support custom GTINs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,32 @@ bad.to_all_valid         # => []
 ```
 
 
+Custom GTINs
+------------
+
+If the standard GTINs provided are not enough for your needs, you can implement your own and register it.
+`BarcodeValidation::GTIN.gtin_classes` contains the ordered list of GTIN classes that are checked if they `handle?(input)`.
+Add your own class to the list, or remove default ones, to tailor it to your needs. For example:
+
+```ruby
+# A custom class that handles any length GTIN as long as it starts with "123".
+# Note that we must still provide a VALID_LENGTH to allow transcoding to other GTINs by zero-padding.
+class MyCustomGTIN < BarcodeValidation::GTIN::Base
+  VALID_LENGTH = 20
+
+  def self.handles?(input)
+    input.start_with?("123") && input.length <= VALID_LENGTH
+  end
+
+  # Custom validity check
+  def valid?
+    self.class.handles?(input) && check_digit.valid?
+  end
+end
+
+BarcodeValidation::GTIN.gtin_classes.unshift MyCustomGTIN
+```
+
 
 Development
 -----------

--- a/lib/barcodevalidation/gtin.rb
+++ b/lib/barcodevalidation/gtin.rb
@@ -12,6 +12,8 @@ require_relative "gtin/gtin14"
 module BarcodeValidation
   module GTIN
     class << self
+      attr_accessor :gtin_classes
+
       def new(input)
         (class_for_input(input) || BarcodeValidation::InvalidGTIN).new(input)
       end
@@ -19,10 +21,10 @@ module BarcodeValidation
       private
 
       def class_for_input(input)
-        [GTIN8, GTIN12, GTIN13, GTIN14].find do |klass|
-          input.to_s.size == klass::VALID_LENGTH
-        end
+        input = input.to_s.freeze
+        gtin_classes.find { |klass| klass.handles?(input) }
       end
     end
+    self.gtin_classes = [GTIN8, GTIN12, GTIN13, GTIN14]
   end
 end

--- a/lib/barcodevalidation/gtin.rb
+++ b/lib/barcodevalidation/gtin.rb
@@ -20,6 +20,12 @@ module BarcodeValidation
         @prioritized_gtin_classes ||= []
       end
 
+      # Ensure the provided class is removed from the list of prioritized GTIN classes.
+      def remove_gtin_class(gtin_class)
+        prioritized_gtin_classes.delete(gtin_class)
+        nil
+      end
+
       private
 
       def class_for_input(input)

--- a/lib/barcodevalidation/gtin.rb
+++ b/lib/barcodevalidation/gtin.rb
@@ -13,16 +13,6 @@ module BarcodeValidation
         (class_for_input(input) || BarcodeValidation::InvalidGTIN).new(input)
       end
 
-      # Classes that inherit from GTIN::Base auto-register themselves here.
-      # Classes can prioritize themselves before others to implement subsets or other means of overlapping ranges.
-      #
-      # @api private Only for internal use.
-      # @see GTIN::Base.prioritize_before For when you want to manipulate priorities.
-      # @see GTIN::Base.abstract_class For when you want to make a GTIN class abstract (i.e. not included in this list)
-      def prioritized_gtin_classes
-        @prioritized_gtin_classes ||= []
-      end
-
       # Adds the provided class to the back of the list of prioritized GTIN classes.
       def append_gtin_class(gtin_class)
         return if gtin_class?(gtin_class)
@@ -53,6 +43,10 @@ module BarcodeValidation
       end
 
       private
+
+      def prioritized_gtin_classes
+        @prioritized_gtin_classes ||= []
+      end
 
       def class_for_input(input)
         input = input.to_s.freeze

--- a/lib/barcodevalidation/gtin.rb
+++ b/lib/barcodevalidation/gtin.rb
@@ -4,6 +4,9 @@ require "forwardable"
 require_relative "invalid_gtin"
 
 module BarcodeValidation
+  # GTIN is responsible for wrapping input in an appropriate GTIN::Base sub-class.
+  # An important part of this involves managing the prioritized list of GTIN classes we use for handling input.
+  # The methods implemented here are used by GTIN::Base to manage this list and prioritize classes.
   module GTIN
     class << self
       def new(input)
@@ -14,7 +17,7 @@ module BarcodeValidation
       # Classes can prioritize themselves before others to implement subsets or other means of overlapping ranges.
       #
       # @api private Only for internal use.
-      # @see GTIN::Base.prioritize_before For when you want to manipulte priorities.
+      # @see GTIN::Base.prioritize_before For when you want to manipulate priorities.
       # @see GTIN::Base.abstract_class For when you want to make a GTIN class abstract (i.e. not included in this list)
       def prioritized_gtin_classes
         @prioritized_gtin_classes ||= []

--- a/lib/barcodevalidation/gtin.rb
+++ b/lib/barcodevalidation/gtin.rb
@@ -22,7 +22,7 @@ module BarcodeValidation
 
       # Adds the provided class to the back of the list of prioritized GTIN classes.
       def append_gtin_class(gtin_class)
-        return if prioritized_gtin_classes.include?(gtin_class)
+        return if gtin_class?(gtin_class)
 
         prioritized_gtin_classes.push(gtin_class)
         nil
@@ -31,6 +31,21 @@ module BarcodeValidation
       # Ensure the provided class is removed from the list of prioritized GTIN classes.
       def remove_gtin_class(gtin_class)
         prioritized_gtin_classes.delete(gtin_class)
+        nil
+      end
+
+      # Is this a registered prioritized GTIN class?
+      # @return [true, false]
+      def gtin_class?(gtin_class)
+        prioritized_gtin_classes.include?(gtin_class)
+      end
+
+      # @param [Class] high_priority_class The higher priority GTIN class you want to move before the low priority class
+      # @param [Class] low_priority_class The low priority GTIN class that the high priority one is moved before
+      def reprioritize_before(high_priority_class, low_priority_class)
+        low_priority_index = prioritized_gtin_classes.index(low_priority_class)
+        remove_gtin_class(high_priority_class)
+        prioritized_gtin_classes.insert(low_priority_index, high_priority_class)
         nil
       end
 

--- a/lib/barcodevalidation/gtin.rb
+++ b/lib/barcodevalidation/gtin.rb
@@ -20,6 +20,14 @@ module BarcodeValidation
         @prioritized_gtin_classes ||= []
       end
 
+      # Adds the provided class to the back of the list of prioritized GTIN classes.
+      def append_gtin_class(gtin_class)
+        return if prioritized_gtin_classes.include?(gtin_class)
+
+        prioritized_gtin_classes.push(gtin_class)
+        nil
+      end
+
       # Ensure the provided class is removed from the list of prioritized GTIN classes.
       def remove_gtin_class(gtin_class)
         prioritized_gtin_classes.delete(gtin_class)

--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -19,6 +19,14 @@ module BarcodeValidation
         BarcodeValidation::InvalidGTIN.new(input, error: e)
       end
 
+      # Does this class (potentially) handle a GTIN that matches the input?
+      # Subclasses can choose to implement their own logic. The default is to look at +VALID_LENGTH+ and use that to match the length of the input the class handles.
+      def self.handles?(input)
+        return false unless self.const_defined?(:VALID_LENGTH)
+
+        input.length == self::VALID_LENGTH
+      end
+
       def valid?
         valid_length == length && check_digit.valid?
       end

--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -34,13 +34,9 @@ module BarcodeValidation
 
       # Ensure this class is earlier in the GTIN classes list than +other_gtin_class+ and thus will get asked earlier if it handles a GTIN.
       def self.prioritize_before(other_gtin_class)
-        other_index = BarcodeValidation::GTIN.prioritized_gtin_classes.index(other_gtin_class)
-        raise ArgumentError, "The class you want to prioritize before is not a registered prioritized GTIN class." if other_index.nil?
+        raise ArgumentError, "The class you want to prioritize before is not a registered prioritized GTIN class." unless GTIN.gtin_class?(other_gtin_class)
 
-        BarcodeValidation::GTIN.remove_gtin_class(self)
-        BarcodeValidation::GTIN.prioritized_gtin_classes.insert(other_index, self)
-
-        nil
+        GTIN.reprioritize_before(self, other_gtin_class)
       end
 
       # This class is abstract and should not be included in the list of GTIN classes that actually implement a GTIN.

--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -41,7 +41,7 @@ module BarcodeValidation
         other_index = BarcodeValidation::GTIN.prioritized_gtin_classes.index(other_gtin_class)
         raise ArgumentError, "The class you want to prioritize before is not a registered prioritized GTIN class." if other_index.nil?
 
-        BarcodeValidation::GTIN.prioritized_gtin_classes.delete(self)
+        BarcodeValidation::GTIN.remove_gtin_class(self)
         BarcodeValidation::GTIN.prioritized_gtin_classes.insert(other_index, self)
 
         nil
@@ -49,9 +49,7 @@ module BarcodeValidation
 
       # This class is abstract and should not be included in the list of GTIN classes that actually implement a GTIN.
       def self.abstract_class
-        BarcodeValidation::GTIN.prioritized_gtin_classes.delete(self)
-
-        nil
+        BarcodeValidation::GTIN.remove_gtin_class(self)
       end
 
       # GTIN::Base is an abstract class. See GTIN8/12/13/14 for implementations of actual GTINs.

--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -29,11 +29,7 @@ module BarcodeValidation
 
       # Upon inheritance, register the subclass so users of the library can dynamically add more GTINs in their own code.
       def self.inherited(subclass)
-        return if BarcodeValidation::GTIN.prioritized_gtin_classes.include?(subclass)
-
-        BarcodeValidation::GTIN.prioritized_gtin_classes.push(subclass)
-
-        nil
+        BarcodeValidation::GTIN.append_gtin_class(subclass)
       end
 
       # Ensure this class is earlier in the GTIN classes list than +other_gtin_class+ and thus will get asked earlier if it handles a GTIN.


### PR DESCRIPTION
Support custom GTINs by adding their class to `BarcodeValidation::GTIN.gtin_classes`

This refactors GTIN handler class lookup so it can be extended without monkeypatching. Developers can add/remove classes in `BarcodeValidation::GTIN.gtin_classes` to control which class wraps a GTIN.

The use case I need this for is internal dummy GTINs that are longer than any of the standard ones and have additional validation rules besides just length.

The Readme is updated to describe the feature.