### PR TITLE
Addressed Rubocop concerns from PR 29

### DIFF
--- a/lib/barcodevalidation/gtin.rb
+++ b/lib/barcodevalidation/gtin.rb
@@ -15,9 +15,7 @@ module BarcodeValidation
 
       # Adds the provided class to the back of the list of prioritized GTIN classes.
       def append_gtin_class(gtin_class)
-        return if gtin_class?(gtin_class)
-
-        prioritized_gtin_classes.push(gtin_class)
+        prioritized_gtin_classes.push(gtin_class) unless gtin_class?(gtin_class)
         nil
       end
 

--- a/lib/barcodevalidation/gtin/base.rb
+++ b/lib/barcodevalidation/gtin/base.rb
@@ -22,7 +22,7 @@ module BarcodeValidation
       # Does this class (potentially) handle a GTIN that matches the input?
       # Subclasses can choose to implement their own logic. The default is to look at +VALID_LENGTH+ and use that to match the length of the input the class handles.
       def self.handles?(input)
-        return false unless self.const_defined?(:VALID_LENGTH)
+        return false unless const_defined?(:VALID_LENGTH)
 
         input.length == self::VALID_LENGTH
       end

--- a/spec/lib/barcodevalidation/gtin_spec.rb
+++ b/spec/lib/barcodevalidation/gtin_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe BarcodeValidation::GTIN do
 
         class_obj = Object.const_get(class_sym)
         BarcodeValidation::GTIN.remove_gtin_class(class_obj)
-        Object.send(:remove_const, class_sym)
+        Object.__send__(:remove_const, class_sym)
       end
     end
 


### PR DESCRIPTION
Rubocop checks in PR #29 did not fire, so small style issues were not discovered until an attempted release. This corrects them, making Rubocop pass. Tests also still pass on my machine.

- GTIN module was 31 lines (max 30), so I inlined a guard clause
- Use of redundant `self.` was removed
- (In a test) prefer `__send__` over `send` when `public_send` is not an option
